### PR TITLE
use opts in openapidocument

### DIFF
--- a/lib/openapi/openapi-document.js
+++ b/lib/openapi/openapi-document.js
@@ -1,19 +1,102 @@
 'use strict';
 
-const validateSchema = require('./schema-validator'); // require('./openapi');
+const validateSchema = require('./schema-validator');
+const allowedOperations = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
 class OpenApiDocument {
   constructor(opts) {
     this.openapi = '3.0.2';
-    this.info = {
+    this.info = opts ? opts.info : {
       title: 'Placeholder API',
       version: '1.0.0'
     };
-    this.paths = {};
-    this.components = {
+    this.servers = opts ? opts.servers : [];
+    this.paths = opts ? opts.path : {};
+    this.components = opts ? opts.components : {
+      schemas: {},
+      responses: {},
+      parameters: {},
+      examples: {},
+      requestBodies: {},
       headers: {},
-      schemas: {}
+      securitySchemes: {},
+      links: {},
+      callbacks: {}
     };
+    this.security = opts ? opts.security : [];
+    this.tags = opts ? opts.tags : [];
+    if (opts && opts.externalDocs) {
+      this.externalDocs = opts.externalDocs;
+    }
+  }
+
+  setPath(name, pathItem) {
+    if (!/^\//.test(name)) {
+      throw new Error(`Invalid path name ${name} - MUST start with "/"`);
+    }
+    this.paths[name] = pathItem;
+  }
+
+  pathExists(name) {
+    return this.paths[name] !== undefined;
+  }
+
+  pathHasOpeations(name) {
+    return this.pathExists(name) && allowedOperations.find(op => this.operationExists(name, op));
+  }
+
+  setPathIfNotExists(name, pathItem) {
+    if (!this.pathExists(name)) {
+      this.setPath(name, pathItem);
+    }
+  }
+
+  addPaths(paths) {
+    for (const name in paths) {
+      this.setPathIfNotExists(name, paths[name]);
+    }
+  }
+
+  setOperation(pathName, operationName, operationItem) {
+    if (!this.pathExists(pathName)) {
+      throw new Error(`Path ${pathName} does not exist`);
+    }
+    if (!allowedOperations.includes(operationName)) {
+      throw new Error(`Illegal path operation: ${operationName}`);
+    }
+    this.paths[pathName][operationName] = operationItem;
+  }
+
+  operationExists(pathName, operationName) {
+    return this.paths[pathName][operationName] !== undefined;
+  }
+
+  setOperationIfNotExists(pathName, operationName, operationItem) {
+    if (!this.operationExists(pathName, operationName)) {
+      this.setOperation(pathName, operationName, operationItem);
+    }
+  }
+
+  setSchema(name, schema) {
+    this.components.schemas[name] = schema;
+  }
+
+  addSchemas(schemas) {
+    for (const name in schemas) {
+      this.setSchema(name, schemas[name]);
+    }
+  }
+
+  schemaExists(name) {
+    return this.components.schemas[name] !== undefined;
+  }
+
+  cleanPaths() {
+    for (const pathName in this.paths) {
+      if (!this.pathHasOpeations(pathName)) {
+        delete this.paths[pathName];
+      }
+    }
   }
 
   valid(opts) {

--- a/lib/openapi/sequelize/openapi-builder.js
+++ b/lib/openapi/sequelize/openapi-builder.js
@@ -17,7 +17,9 @@ class SequelizeOpenApiBuilder extends OpenApiBuilder {
     super(opts);
     this.model = model;
     this.basePath = basePath;
-    this.opts = opts;
+    this.tags = opts.tags || [];
+    this.operationIdPrefix = opts.operationIdPrefix || 'SequelizeOpenApiBuilder';
+    this.pathOpts = opts.pathOpts || {};
     this.idParameter = SequelizeOpenApiBuilder.createIdParameterSpecification(model);
     this.modelRef = {$ref: `#/components/schemas/${model.name}`};
   }
@@ -53,7 +55,7 @@ class SequelizeOpenApiBuilder extends OpenApiBuilder {
   }
 
   getPathOptions(path) {
-    return this.opts[path] || {};
+    return this.pathOpts[path] || {};
   }
 
   createPathItemStub(path) {
@@ -70,8 +72,8 @@ class SequelizeOpenApiBuilder extends OpenApiBuilder {
   createBasePathSpecification(path, operation) {
     const pathOpts = this.getPathOptions(path)[operation] || {};
     const baseSpecification = {
-      tags: ['exseq', this.model.name],
-      operationId: `exseq-${this.basePath}${path}-${operation}`,
+      tags: [...this.tags, this.model.name],
+      operationId: `${this.operationIdPrefix}-${this.basePath}${path}-${operation}`,
       callbacks: pathOpts.callbacks || {},
       deprecated: pathOpts.deprecated || false,
       security: pathOpts.security || [],


### PR DESCRIPTION
OpenApiDocument now uses opts in its constructor. If opts is given all fields but openapi (openapi version) are overridden.
The option to configure the OpenApiDocument created/filled by exseq is called opts.openapi.document and can be either an instance of OpenApiDocument or an opts object for OpenApiDocument's constructor.

I've added some util functions to OpenApiDocument (setPathIfExists, etc.) and changed index.js to actually use them. In doing that I've also fixed some bugs which caused some operations not to be created.

I've also added the function cleanPaths do OpenApiDocument which removes all pathItems that have no operations. This function is called before validating the OpenApiDocument at the end of index.js.
